### PR TITLE
TypeError fix for Yopmail 1.4

### DIFF
--- a/yopmail/yopmail.py
+++ b/yopmail/yopmail.py
@@ -4,6 +4,7 @@ import string
 import re
 import requests
 from bs4 import BeautifulSoup
+from typing import Optional
 
 
 class YopmailHTML:
@@ -42,7 +43,7 @@ class Yopmail:
         self.ycons = None
         self.ytime = None
 
-    def request(self, url: str, params=None, proxies=None, context: str = None) -> requests.models.Response|None:
+    def request(self, url: str, params=None, proxies=None, context: str = None) -> Optional[requests.models.Response]:
         proxies = proxies if proxies is not None else self.proxies
         try:
             if self.yp is None:


### PR DESCRIPTION
Hello! 
I had a problem with Yopmail==1.4 on Python 3.9
```
    class Yopmail:
        def __init__(self, username, proxies=None):
            if not re.compile("^[-a-zA-Z0-9@_.+]{1,}$").match(username):
                raise ValueError("Username is not valid")
            self.username = username.split('@')[0]
            self.url = 'https://yopmail.com/en/'
            self.session = requests.Session()
            self.jar = requests.cookies.RequestsCookieJar()
            self.proxies = proxies

            # Yopmail needed parameters:
            self.yp = None
            self.yj = None
            self.ycons = None
            self.ytime = None

>       def request(self, url: str, params=None, proxies=None, context: str = None) -> requests.models.Response|None:
E       TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'

venv\lib\site-packages\yopmail\yopmail.py:45: TypeError
```

According to the [StackOverflow](https://stackoverflow.com/questions/76712720/typeerror-unsupported-operand-types-for-type-and-nonetype)

> str | None syntax is only supported in 3.10 or later



I made slight changes 
```
from typing import Optional
    def request(self, url: str, params=None, proxies=None, context: str = None) -> Optional[requests.models.Response]:
```
and the problem has gone